### PR TITLE
feat: add generate-mixed-colors function

### DIFF
--- a/functions/_colors.scss
+++ b/functions/_colors.scss
@@ -3,6 +3,11 @@
 @use "sass:math";
 @use "sass:string";
 
+@use './type-checking' as check;
+
+@use '../node_modules/sass-true/sass/throw' as throw;
+$_is-test: false !default;
+
 /// Convert HEX colors to R, G, B values
 /// @param {Color} $color
 /// @return {String}
@@ -106,11 +111,26 @@
 	$steps: 20,
 	$color2-peak: 11,
 ) {
+	@if(check.is-color($color1) == false) {
+		@return throw.error("❌  ===> The color1 parameter must be a color.", $catch: $_is-test);
+	}
+	@if(check.is-color($color2) == false) {
+		@return throw.error("❌  ===> The color2 parameter must be a color.", $catch: $_is-test);
+	}
+	@if(check.is-color($color3) == false) {
+		@return throw.error("❌  ===> The color3 parameter must be a color.", $catch: $_is-test);
+	}
+	@if(check.is-integer($steps) == false) {
+		@return throw.error("❌  ===> The steps parameter must be an integer.", $catch: $_is-test);
+	}
+	@if(check.is-integer($color2-peak) == false) {
+		@return throw.error("❌  ===> The color2-peak parameter must be an integer.", $catch: $_is-test);
+	}
 	@if ($color2-peak > $steps) {
-		@error "The peak point for color2 must be less than or equal to the number of steps.";
+		@return throw.error("❌  ===> The peak point for color2 must be less than or equal to the number of steps.", $catch: $_is-test);
 	}
 	@if ($color2-peak < 1) {
-		@error "The peak point for color2 must be greater than or equal to 1.";
+		@return throw.error("❌  ===> The peak point for color2 must be greater than or equal to 1.", $catch: $_is-test);
 	}
 
 	$colorMap: (1: $color1);

--- a/functions/_colors.scss
+++ b/functions/_colors.scss
@@ -81,3 +81,60 @@
 
   @return $shades;
 }
+
+/// Generate a map of colors that are mixed between three colors with a peak point for color2.
+/// @param $color1 - The first color.
+/// @param $color2 - The second color.
+/// @param $color3 - The third color.
+/// @param $steps - The number of steps to generate.
+/// @param $color2-peak - The peak point for color2.
+/// @return {Map} - The map of colors.
+/// @group Color
+/// @author https://github.com/red-freak
+/// @since v2.5.0
+///
+/// @example
+///    @debug generate-mixed-colors(green, yellow, red, 7, 4);
+///
+/// @example CSS - Output CSS
+///    (1: green, 2: #80c000, 3: #bfdf00, 4: yellow, 5: #ffaa00, 6: #ff5500, 7: red)
+///
+@function generate-mixed-colors(
+	$color1,
+	$color2,
+	$color3,
+	$steps: 20,
+	$color2-peak: 11,
+) {
+	@if ($color2-peak > $steps) {
+		@error "The peak point for color2 must be less than or equal to the number of steps.";
+	}
+	@if ($color2-peak < 1) {
+		@error "The peak point for color2 must be greater than or equal to 1.";
+	}
+
+	$colorMap: (1: $color1);
+
+	@if($color2-peak > 2) {
+		@for $i from 2 through $color2-peak - 1 {
+			$percentage: (math.div(1, $color2-peak) * ($color2-peak - $i));
+			$color: mix($color1, $color2, $percentage * 100%);
+			$colorMap: map.merge($colorMap, ($i: $color));
+		}
+	}
+
+	$colorMap: map.merge($colorMap, ($color2-peak: $color2));
+
+	@if($color2-peak < $steps) {
+		@for $i from $color2-peak+1 through $steps - 1 {
+			$percentage: (math.div(1, $steps - $color2-peak) * ($steps - $i));
+			$color: mix($color2, $color3, $percentage * 100%);
+
+			$colorMap: map.merge($colorMap, ($i: $color));
+		}
+
+		$colorMap: map.merge($colorMap, ($steps: $color3))
+	}
+
+	@return $colorMap;
+}

--- a/functions/_type-checking.scss
+++ b/functions/_type-checking.scss
@@ -126,3 +126,12 @@
 	@return is-length($value) or is-percentage($value) or
 		list.index('top' 'right' 'bottom' 'left' 'center', $value) != null;
 }
+
+/// Check if its a color value
+/// @param {Void} $value - Value to check
+/// @group Type-Checking
+/// @author https://github.com/red-freak
+/// @since v2.5.0
+@function is-color($value) {
+	@return meta.type-of($value) == 'color';
+}

--- a/tests/colors-generate-mixed-colors.spec.scss
+++ b/tests/colors-generate-mixed-colors.spec.scss
@@ -44,5 +44,8 @@ $_is-test: true;
 		@include true.assert-equal(
 			generate-mixed-colors(green, yellow, red), (1: green, 2: #2e9700, 3: #46a300, 4: #5dae00, 5: #74ba00, 6: #8bc500, 7: #a2d100, 8: #b9dc00, 9: #d1e800, 10: #e8f300, 11: yellow, 12: #ffe300, 13: #ffc600, 14: #ffaa00, 15: #ff8e00, 16: #ff7100, 17: #ff5500, 18: #ff3900, 19: #ff1c00, 20: red)
 		);
+		@include true.assert-equal(
+			generate-mixed-colors(#7ed321, #ffc700, #cc0000), (1: #7ed321, 2: #95d11b, 3: #a1d018, 4: #adcf15, 5: #b9ce12, 6: #c4cc0f, 7: #d0cb0c, 8: #dcca09, 9: #e8c906, 10: #f3c803, 11: #ffc700, 12: #f9b100, 13: #f49b00, 14: #ee8500, 15: #e86f00, 16: #e35800, 17: #dd4200, 18: #d72c00, 19: #d21600, 20: #cc0000)
+		);
 	}
 }

--- a/tests/colors-generate-mixed-colors.spec.scss
+++ b/tests/colors-generate-mixed-colors.spec.scss
@@ -1,0 +1,48 @@
+//@use 'true';
+$_is-test: true;
+@use '../node_modules/sass-true/sass/true' as true;
+@import '../functions/_colors.scss';
+
+
+@include true.describe('generate-mixed-colors()') {
+	@include true.it('should throw an error if the step and peak parameters are wrong') {
+		@include true.assert-equal(
+			generate-mixed-colors(1, 1, 1), 'ERROR: ❌  ===> The color1 parameter must be a color.'
+		);
+		@include true.assert-equal(
+			generate-mixed-colors(green, 1, 1), 'ERROR: ❌  ===> The color2 parameter must be a color.'
+		);
+		@include true.assert-equal(
+			generate-mixed-colors(green, yellow, 1), 'ERROR: ❌  ===> The color3 parameter must be a color.'
+		);
+		@include true.assert-equal(
+			generate-mixed-colors(green, yellow, red, "hallo"), 'ERROR: ❌  ===> The steps parameter must be an integer.'
+		);
+		@include true.assert-equal(
+			generate-mixed-colors(green, yellow, red, 10, "welt"), 'ERROR: ❌  ===> The color2-peak parameter must be an integer.'
+		);
+		@include true.assert-equal(
+			generate-mixed-colors(green, yellow, red, 0, 2), 'ERROR: ❌  ===> The peak point for color2 must be less than or equal to the number of steps.'
+		);
+		@include true.assert-equal(
+			generate-mixed-colors(green, yellow, red, 0, 0), 'ERROR: ❌  ===> The peak point for color2 must be greater than or equal to 1.'
+		);
+		@include true.assert-equal(
+			generate-mixed-colors(green, yellow, red, -1, -1), 'ERROR: ❌  ===> The peak point for color2 must be greater than or equal to 1.'
+		);
+	}
+	@include true.it('should return expected color maps') {
+		@include true.assert-equal(
+			generate-mixed-colors(green, yellow, red, 1, 1), (1: yellow)
+		);
+		@include true.assert-equal(
+			generate-mixed-colors(green, yellow, red, 3, 2), (1: green, 2: yellow, 3: red)
+		);
+		@include true.assert-equal(
+			generate-mixed-colors(green, yellow, red, 2, 1), (1: yellow, 2: red)
+		);
+		@include true.assert-equal(
+			generate-mixed-colors(green, yellow, red), (1: green, 2: #2e9700, 3: #46a300, 4: #5dae00, 5: #74ba00, 6: #8bc500, 7: #a2d100, 8: #b9dc00, 9: #d1e800, 10: #e8f300, 11: yellow, 12: #ffe300, 13: #ffc600, 14: #ffaa00, 15: #ff8e00, 16: #ff7100, 17: #ff5500, 18: #ff3900, 19: #ff1c00, 20: red)
+		);
+	}
+}


### PR DESCRIPTION
Added a function to generate a color map for mixing 3 colors. e.g. for showing bad ok and good states.

```scss
$goodScoreColor: #7ED321;
$okScoreColor: #FFC700;
$badScoreColor: #CC0000;

$colorMap: generate-mixed-colors($goodScoreColor, $okScoreColor, $badScoreColor);

@each $key, $value in $colorMap {
    .step-#{$key} {
        background-color: $value;
    }
}
```
will generate
```css
.step-1 {
  background-color: #7ED321;
}

.step-2 {
  background-color: #95d11b;
}

.step-3 {
  background-color: #a1d018;
}

.step-4 {
  background-color: #adcf15;
}

.step-5 {
  background-color: #b9ce12;
}

.step-6 {
  background-color: #c4cc0f;
}

.step-7 {
  background-color: #d0cb0c;
}

.step-8 {
  background-color: #dcca09;
}

.step-9 {
  background-color: #e8c906;
}

.step-10 {
  background-color: #f3c803;
}

.step-11 {
  background-color: #FFC700;
}

.step-12 {
  background-color: #f9b100;
}

.step-13 {
  background-color: #f49b00;
}

.step-14 {
  background-color: #ee8500;
}

.step-15 {
  background-color: #e86f00;
}

.step-16 {
  background-color: #e35800;
}

.step-17 {
  background-color: #dd4200;
}

.step-18 {
  background-color: #d72c00;
}

.step-19 {
  background-color: #d21600;
}

.step-20 {
  background-color: #CC0000;
}
```